### PR TITLE
Replace `.getSpec` with `.specs` to obtain specs of an object

### DIFF
--- a/Classes/Influx.sc
+++ b/Classes/Influx.sc
@@ -457,11 +457,7 @@ Influx :InfluxBase {
 		// 1. Passed in via param
 		// 2. local specs in the object (if object responds to specs)
 		// 3. global specs defined in ControlSpec.specs
-		specs = if(object.respondsTo('specs'), {
-			specs ?? {object.specs} ? ControlSpec.specs;
-		}, {
-			specs ?? ControlSpec.specs;	
-		});
+		specs = specs ?? {object.tryPerform('specs')} ? ControlSpec.specs;
 		
 		funcName = funcName ?? { object.key };
 		paramNames = paramNames

--- a/Classes/Influx.sc
+++ b/Classes/Influx.sc
@@ -453,8 +453,16 @@ Influx :InfluxBase {
 		var mappedKeyValList;
 		var offDict = ();
 
-		// Look for specs: Passed in via param, local specs in the object or global specs defined in ControlSpec.specs
-		specs = specs ?? {object.getSpec} ? ControlSpec.specs;
+		// Look for specs with priority
+		// 1. Passed in via param
+		// 2. local specs in the object (if object responds to specs)
+		// 3. global specs defined in ControlSpec.specs
+		specs = if(object.respondsTo('specs'), {
+			specs ?? {object.specs} ? ControlSpec.specs;
+		}, {
+			specs ?? ControlSpec.specs;	
+		});
+		
 		funcName = funcName ?? { object.key };
 		paramNames = paramNames
 		?? { object.getHalo(\orderedNames); }


### PR DESCRIPTION
The code currently uses `.getSpec` which will always return `nil` if called without params (correct me if I am wrong). Instead it would be better to use `.specs` which returns the explicitly stated/attached specs for a proxy.

As `.specs` is not attached to `Object` (`.getSpec` is) I wrapped the code which checks if the object responds to `.specs` in order to avoid breakage.

Also see https://github.com/supercollider-quarks/Influx/pull/5#issuecomment-1879887967
